### PR TITLE
Lake build and execute support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Key Bindings and Commands
 | <kbd>C-c C-k</kbd> | show the keystroke needed to input the symbol under the cursor                  |
 | <kbd>C-c C-d</kbd> | recompile & reload imports (`lean4-refresh-file-dependencies`)                  |
 | <kbd>C-c C-x</kbd> | execute Lean in stand-alone mode (`lean4-std-exe`)                              |
+| <kbd>C-c C-p C-l</kbd> | builds package with lake (`lean4-lake-build`)                                   |
 | <kbd>C-c C-i</kbd> | toggle info view showing goals and errors at point (`lean4-toggle-info-buffer`) |
 | <kbd>C-c ! n</kbd> | flycheck: go to next error                                                      |
 | <kbd>C-c ! p</kbd> | flycheck: go to previous error                                                  |

--- a/lean4-lake.el
+++ b/lean4-lake.el
@@ -1,0 +1,22 @@
+(defun lean4-lake-find-dir-in (dir)
+  (when dir
+    (or (lean4-lake-find-dir-in (f-parent dir))
+        (when (f-exists? (f-join dir "lakefile.lean")) dir))))
+
+(defun lean4-lake-find-dir ()
+  (and (buffer-file-name)
+       (lean4-lake-find-dir-in (f-dirname (buffer-file-name)))))
+
+(defun lean4-lake-find-dir-safe ()
+  (or (lean4-lake-find-dir)
+      (error (format "cannot find lakefile.lean for %s" (buffer-file-name)))))
+
+(defun lean4-lake-build ()
+  "Call lake build"
+  (interactive)
+  (let* ((default-directory (file-name-as-directory (lean4-lake-find-dir-safe))))
+    (with-existing-directory
+      (compile (concat (lean4-get-executable "lake") " build")))))
+
+(provide 'lean4-lake)
+

--- a/lean4-lake.el
+++ b/lean4-lake.el
@@ -1,3 +1,5 @@
+(require 'lean4-util)
+
 (defun lean4-lake-find-dir-in (dir)
   (when dir
     (or (lean4-lake-find-dir-in (f-parent dir))
@@ -16,7 +18,7 @@
   (interactive)
   (let* ((default-directory (file-name-as-directory (lean4-lake-find-dir-safe))))
     (with-existing-directory
-      (compile (concat (lean4-get-executable "lake") " build")))))
+      (compile (concat (lean4-get-executable lean4-lake-name) " build")))))
 
 (provide 'lean4-lake)
 

--- a/lean4-lake.el
+++ b/lean4-lake.el
@@ -2,8 +2,8 @@
 
 (defun lean4-lake-find-dir-in (dir)
   (when dir
-    (or (lean4-lake-find-dir-in (f-parent dir))
-        (when (f-exists? (f-join dir "lakefile.lean")) dir))))
+    (or (when (f-exists? (f-join dir "lakefile.lean")) dir)
+	(lean4-lake-find-dir-in (f-parent dir)))))
 
 (defun lean4-lake-find-dir ()
   (and (buffer-file-name)

--- a/lean4-mode.el
+++ b/lean4-mode.el
@@ -41,6 +41,7 @@
 (require 'lean4-leanpkg)
 (require 'lean4-dev)
 (require 'lean4-fringe)
+(require 'lean4-lake)
 
 (defun lean4-compile-string (exe-name args file-name)
   "Concatenate EXE-NAME, ARGS, and FILE-NAME."
@@ -103,6 +104,7 @@
   (local-set-key lean4-keybinding-leanpkg-configure         #'lean4-leanpkg-configure)
   (local-set-key lean4-keybinding-leanpkg-build             #'lean4-leanpkg-build)
   (local-set-key lean4-keybinding-leanpkg-test              #'lean4-leanpkg-test)
+  (local-set-key lean4-keybinding-lake-build                #'lean4-lake-build)
   (local-set-key lean4-keybinding-refresh-file-dependencies #'lean4-refresh-file-dependencies)
   ;; This only works as a mouse binding due to the event, so it is not abstracted
   ;; to avoid user confusion.

--- a/lean4-settings.el
+++ b/lean4-settings.el
@@ -24,6 +24,12 @@
     (t             "lean"))
   "Default executable name of Lean")
 
+(defvar-local lean4-default-lake-name
+  (cl-case system-type
+    ('windows-nt   "lake.exe")
+    (t             "lake"))
+  "Default executable name of Lake")
+
 (defcustom lean4-rootdir nil
   "Full pathname of lean root directory. It should be defined by user."
   :group 'lean
@@ -32,6 +38,11 @@
 (defcustom lean4-executable-name lean4-default-executable-name
   "Name of lean executable"
   :group 'lean
+  :type 'string)
+
+(defcustom lean4-lake-name lean4-default-lake-name
+  "Name of lake executable"
+  :group 'lake
   :type 'string)
 
 (defcustom lean4-memory-limit 1024

--- a/lean4-settings.el
+++ b/lean4-settings.el
@@ -118,6 +118,9 @@ using `font-lock-comment-face' instead of the `✝` suffix used by Lean."
 (defcustom lean4-keybinding-leanpkg-test (kbd "C-c C-p C-t")
   "Lean Keybinding for lean4-leanpkg-test"
   :group 'lean4-keybinding :type 'key-sequence)
+(defcustom lean4-keybinding-lake-build (kbd "C-c C-p C-l")
+  "Lean Keybinding for lean4-lake-build"
+  :group 'lean4-keybinding :type 'key-sequence)
 (defcustom lean4-keybinding-refresh-file-dependencies (kbd "C-c C-d")
   "Lean Keybinding for lean4-refresh-file-dependencies"
   :group 'lean4-keybinding :type 'key-sequence)


### PR DESCRIPTION
I have finally polished the support for lake.

Two features:
1. `lean4-execute`  detects if you are in lake project and executes with `lake env ...`
2.  command `lean4-lake-build` runs `lake build`

Tested only on Linux only and I have assumed that the executable for lake is `lake.exe` on Windows.