### PR TITLE
chore: don't bind M-. to non-existent function

### DIFF
--- a/lean4-mode.el
+++ b/lean4-mode.el
@@ -103,7 +103,6 @@
   (local-set-key lean4-keybinding-std-exe1                  #'lean4-std-exe)
   (local-set-key lean4-keybinding-std-exe2                  #'lean4-std-exe)
   (local-set-key lean4-keybinding-show-key                  #'quail-show-key)
-  (local-set-key lean4-keybinding-find-definition           #'lean4-find-definition)
   (local-set-key lean4-keybinding-tab-indent                #'lean4-tab-indent)
   (local-set-key lean4-keybinding-hole                      #'lean4-hole)
   (local-set-key lean4-keybinding-lean4-toggle-info         #'lean4-toggle-info)
@@ -139,7 +138,6 @@
     ["Toggle message boxes" lean4-message-boxes-toggle         t]
     ["Highlight pending tasks"  lean4-server-toggle-show-pending-tasks
      :active t :style toggle :selected lean4-server-show-pending-tasks]
-    ["Find definition at point" lean4-find-definition          t]
     "-----------------"
     ["List of errors"       flycheck-list-errors              flycheck-mode]
     "-----------------"

--- a/lean4-settings.el
+++ b/lean4-settings.el
@@ -102,9 +102,6 @@ using `font-lock-comment-face' instead of the `✝` suffix used by Lean."
 (defcustom lean4-keybinding-server-switch-version (kbd "C-c C-s")
   "Lean Keybinding for lean4-server-switch-version"
   :group 'lean4-keybinding :type 'key-sequence)
-(defcustom lean4-keybinding-find-definition (kbd "M-.")
-  "Lean Keybinding for find-definition"
-  :group 'lean4-keybinding  :type 'key-sequence)
 (defcustom lean4-keybinding-tab-indent (kbd "TAB")
   "Lean Keybinding for tab-indent"
   :group 'lean4-keybinding  :type 'key-sequence)


### PR DESCRIPTION
Not sure if this is correct, but the default `M-.` binding provided by xref.el works fine with `lsp-mode` here.