### PR TITLE
Update *Lean Goal* if visible on any frame.

### DIFF
--- a/lean4-info.el
+++ b/lean4-info.el
@@ -59,8 +59,8 @@
 (defun lean4-info-buffer-active (buffer)
   "Checks whether the given info buffer should show info for the current buffer"
   (and
-   ;; info buffer visible
-   (get-buffer-window buffer)
+   ;; info buffer visible (on any frame)
+   (get-buffer-window buffer t)
    ;; current window of current buffer is selected (i.e., in focus)
    (eq (current-buffer) (window-buffer))))
 


### PR DESCRIPTION
Pass the argument `ALL-FRAMES` to `t` to consider all windows on all
existing frames.

I use [`frame-mode`](https://github.com/IvanMalison/frame-mode) to convert all splits into frames, and I manage my "splits" (frames) using `i3`. This patch allows the `*Lean Goal*` buffer to be updated if it is visible on *any frame*. 