### PR TITLE
Make Info buffer read-only

### DIFF
--- a/lean4-info.el
+++ b/lean4-info.el
@@ -41,14 +41,16 @@
        (setq buffer-read-only nil)
        (erase-buffer)
        (setq standard-output buf)
-       . ,body)))
+       ,@body
+       (setq buffer-read-only t))))
 
 (defun lean4-ensure-info-buffer (buffer)
   (unless (get-buffer buffer)
     (with-current-buffer (get-buffer-create buffer)
       (buffer-disable-undo)
       (magit-section-mode)
-      (set-syntax-table lean4-syntax-table))))
+      (set-syntax-table lean4-syntax-table)
+      (setq buffer-read-only t))))
 
 (defun lean4-toggle-info-buffer (buffer)
   (-if-let (window (get-buffer-window buffer))


### PR DESCRIPTION
This ensures that one does not accidentally delete
information being displayed by running `kill` commands.

It is also sensible that the buffer is read-only, as `*Lean Goal*` is meant to be a read-only display of the current state.
