### PR TITLE
Debounce refreshes of the info-mode

### DIFF
--- a/lean4-info.el
+++ b/lean4-info.el
@@ -132,6 +132,115 @@
                         'font-lock-face 'font-lock-comment-face)
             'fixedcase 'literal)))))))
 
+
+;; Debouncing
+;; ~~~~~~~~~~~
+;; We want to update the Lean4 info buffer as seldom as possible,
+;; since magit-section is slow at rendering. We
+;; wait a small duration ('debounce-delay-sec') when we get a
+;; redisplay request, to see if there is a redisplay request in the
+;; future that invalidates the current request (debouncing).
+;; Pictorially,
+;; (a) One request:
+;; --r1
+;; --r1.wait
+;; ----------r1.render
+;; (b) Two requests in quick succession:
+;; --r1
+;; --r1.wait
+;; --------r2(cancel r1.wait)
+;; --------r2.wait
+;; ---------------r2.render
+;; (c) Two requests, not in succession:
+;; --r1
+;; --r1.wait
+;; ---------r1.render
+;; ------------------r2
+;; ------------------r2.wait
+;; -------------------------r2.render
+;; This delaying can lead to a pathological case where we continually
+;; stagger, while not rendering anything:
+;; --r1
+;; --r1.wait
+;; --------r2(cancel r1.wait)
+;; --------r2.wait
+;; --------------r3(cancel r2.wait)
+;; ---------------r3.wait
+;; ---------------------r4(cancel r3.wait)
+;; ---------------------...
+;; We prevent this pathological case by keeping track of when
+;; when we began debouncing in 'lean4-info-buffer-debounce-begin-time'.
+;; If we have been debouncing for longer than
+;; 'lean4-info-buffer-debounce-upper-bound-sec', then we
+;; immediately write instead of debouncing;
+;; 'max-debounces' times. Upon trying to stagger the
+;; 'max-debounces'th request, we immediately render:
+;; begin-time:nil----t0----------------nil-------
+;;            -------r1                |
+;;            -------r1.wait           |
+;;            -------|-----r2(cancel r1.wait)
+;;            -------|-----r2.wait     |
+;;            -------|-----------r3(cancel r2.wait)
+;;            -------|-----------r3.wait
+;;            -------|-----------------r4(cancel r3.wait)
+;;            -------|-----------------|
+;;                   >-----------------<
+;;                   >longer than 'debounce-upper-bound-sec'<
+;;            -------------------------r4.render(FORCED)
+
+
+(defcustom lean4-info-buffer-debounce-delay-sec 0.1
+  "Duration of time we wait before writing to *Lean Goal*")
+
+
+(defvar lean4-info-buffer-debounce-timer nil
+  "Timer that is used to debounce Lean4 info view refresh.")
+
+
+(defvar lean4-info-buffer-debounce-begin-time nil
+  "Time we have begun debouncing. Is 'nil' if we are not
+   currently debouncing. Otherwise, is a timestamp as given
+   by 'current-time'.")
+
+(defcustom lean4-info-buffer-debounce-upper-bound-sec
+  0.5
+  "Maximum time we are allowed to stagger debouncing. If we recieve
+   a request such that we have been debouncing for longer than
+   'lean4-info-buffer-debounce-begin-time', then we immediately
+   run the request.")
+
+;;  Debounce implementation modifed from lsp-lens
+;; https://github.com/emacs-lsp/lsp-mode/blob/2f0ea2e396ec9a570f2a2aeb097c304ddc61ebee/lsp-lens.el#L140
+(defun lean4-info-buffer-redisplay-debounced ()
+  "Debounced version of lean4-info-buffer-redisplay that ensures that
+   info buffer is not repeatedly written to. This is to prevent lag, because
+   magit is quite slow at building sections."
+  ;;  if we have not begun debouncing, setup debouncing begin time.
+  (if (not lean4-info-buffer-debounce-begin-time) 
+      (setq lean4-info-buffer-debounce-begin-time (current-time)))
+  ;; if time since we began debouncing is too long...
+  (if (>= (time-convert
+	   (time-subtract (current-time)
+			  lean4-info-buffer-debounce-begin-time)
+	   'integer)
+	  lean4-info-buffer-debounce-upper-bound-sec)
+      ;;  then redisplay immediately.
+      (progn
+	;;  We have stopped debouncing.
+	(setq lean4-info-buffer-debounce-begin-time nil)
+	(lean4-info-buffer-redisplay))
+    ;; else cancel current timer, create new debounced timer.
+    (-some-> lean4-info-buffer-debounce-timer cancel-timer)
+    (setq lean4-info-buffer-debounce-timer ; set new timer
+	  (run-with-timer
+	   lean4-info-buffer-debounce-delay-sec
+	   nil				; don't repeat timer
+	   (lambda ()
+	     ;; We have stopped debouncing.
+	     (setq lean4-info-buffer-debounce-begin-time nil)
+	     (lean4-info-buffer-redisplay))))))
+
+
 (defun lean4-info-buffer-refresh ()
   (when (lean4-info-buffer-active lean4-info-buffer-name)
     (lsp-request-async
@@ -139,7 +248,7 @@
      (lsp--text-document-position-params)
      (-lambda ((_ &as &lean:PlainGoal? :goals))
        (setq lean4-goals goals)
-       (lean4-info-buffer-redisplay))
+       (lean4-info-buffer-redisplay-debounced))
      :error-handler #'ignore
      :mode 'tick
      :cancel-token :plain-goal)
@@ -148,7 +257,7 @@
      (lsp--text-document-position-params)
      (-lambda ((_ &as &lean:PlainTermGoal? :goal))
        (setq lean4-term-goal goal)
-       (lean4-info-buffer-redisplay))
+       (lean4-info-buffer-redisplay-debounced))
      :error-handler #'ignore
      :mode 'tick
      :cancel-token :plain-term-goal)

--- a/lean4-mode.el
+++ b/lean4-mode.el
@@ -161,8 +161,8 @@
     (before-save-hook                    . lean4-whitespace-cleanup)
     ;; info view
     ;; update errors immediately, but delay querying goal
-    (flycheck-after-syntax-check-hook    . lean4-info-buffer-redisplay)
-    (post-command-hook                   . lean4-info-buffer-redisplay)
+    (flycheck-after-syntax-check-hook    . lean4-info-buffer-redisplay-debounced)
+    (post-command-hook                   . lean4-info-buffer-redisplay-debounced)
     (lsp-on-idle-hook                    . lean4-info-buffer-refresh)
     )
   "Hooks which lean4-mode needs to hook in.


### PR DESCRIPTION
This prevents emacs from lagging when scrolling
through a file that has many `#print` messages, or when
there are many errors.

This was discovered when writing [this lean file with many errors](https://gist.github.com/bollu/0fba51802892dc81f0f0564450173711#file-slow-lean-mode-lean).

The [profiler output (use `M-x profiler-find-profile` to view](https://gist.github.com/bollu/0fba51802892dc81f0f0564450173711#file-profile) is below:

```
   3832  38% + catch
        3632  36% + #<lambda -0x1e43a018eefeb959> ;; magit closure
         325   3% + linum-update-window
         279   2% + complete-with-action
         254   2% + while
         227   2% + eieio-oref
         116   1% + magit-insert-child-count
 ...
```

The debounce implementation was taken from [lsp-lens](https://github.com/emacs-lsp/lsp-mode/blob/2f0ea2e396ec9a570f2a2aeb097c304ddc61ebee/lsp-lens.el#L140)