### PR TITLE
fix: Allow lean4-mode in anonymous buffers

### DIFF
--- a/lean4-mode.el
+++ b/lean4-mode.el
@@ -185,9 +185,12 @@ enabled and disabled respectively.")
 (defun lean4-create-lsp-workspace ()
   "This will allow us to use emacs when a repo contains
 multiple lean packages"
-  (when-let ((root (vc-find-root (buffer-file-name)
-                                 "lakefile.lean")))
-    (lsp-workspace-folders-add root)))
+  (let (buff-name (buffer-file-name))
+    (progn
+      (if (not buff-name) (setq buff-name (buffer-file-name (window-buffer (selected-window)))))
+      (when-let ((root (vc-find-root buff-name
+                                     "lakefile.lean")))
+          (lsp-workspace-folders-add root)))))
 
 ;; Automode List
 ;;;###autoload


### PR DESCRIPTION
When putting Lean4 snippets in org mode buffers, on export it
calls (with-temp-buffer) to syntax highlight the code.
This fails when lean4-mode tries to find the associated lakefile.lean,
because there's no associated filesystem.

If the (buffer-find-file) function returns nil, we instead get the
filename of the buffer in the currently selected window.
This should be the original org-mode file, which is what we need.

This isn't a perfect solution, but it's a vast improvement.