### PR TITLE
[feat] Add Info View buttons: goto file/line/col

### DIFF
--- a/lean4-info.el
+++ b/lean4-info.el
@@ -93,7 +93,6 @@
 	      (magit-insert-heading)
 	      (insert-button (format "%s %d:%d" uri (1+ (lsp-translate-line line)) (lsp-translate-column character))
 			     'action (lambda (btn)
-				       (message (format "clicked %s" uri))
 				       (with-current-buffer (find-file-other-window (lsp--uri-to-path uri))
 					 (goto-line (lsp-translate-line line))
 					 (move-to-column (lsp-translate-column character)))))


### PR DESCRIPTION
This allows one to press <RET> on the link to go to
the corresponding file/line/column.

Screenshot attached, where the section headers are now clickable links, that take one to the correct file/line/column

![image](https://user-images.githubusercontent.com/1694861/171754607-ed3b9d6e-31d9-40e0-a704-b24c9dca0f5a.png)
