### PR TITLE
fix: `time-convert` is too new. Use `time-to-seconds`

### DIFF
--- a/lean4-info.el
+++ b/lean4-info.el
@@ -219,10 +219,9 @@
   (if (not lean4-info-buffer-debounce-begin-time) 
       (setq lean4-info-buffer-debounce-begin-time (current-time)))
   ;; if time since we began debouncing is too long...
-  (if (>= (time-convert
+  (if (>= (time-to-seconds
 	   (time-subtract (current-time)
-			  lean4-info-buffer-debounce-begin-time)
-	   'integer)
+			  lean4-info-buffer-debounce-begin-time))
 	  lean4-info-buffer-debounce-upper-bound-sec)
       ;;  then redisplay immediately.
       (progn


### PR DESCRIPTION
`time-to-seconds` is quite old: `C-h f time-to-seconds` says:
>  Probably introduced at or before Emacs version 24.4.

As a bonus, it conveys intent slightly better, as `time-to-seconds` is a
more descriptive function name.

Closes #19