### PR TITLE
doc: update straight instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ Alternatively if you are a fan of `use-package` and `straight.el` you
 can use:
 ```
 (use-package lean4-mode
-  :straight (lean4-mode :type git :host github :repo "leanprover/lean4-mode")
+  :straight (lean4-mode
+	     :type git
+	     :host github
+	     :repo "leanprover/lean4-mode"
+	     :files ("*.el" "data"))
   ;; to defer loading the package until required
   :commands (lean4-mode))
 ```


### PR DESCRIPTION
The current straight instructions wont finde the abbreviations.json.