### PR TITLE
Revert "Package-Requires: ((emacs "28.3" --> "26.3") ...)

### DIFF
--- a/lean4-lake.el
+++ b/lean4-lake.el
@@ -17,9 +17,8 @@
 (defun lean4-lake-build ()
   "Call lake build"
   (interactive)
-  (let* ((default-directory (file-name-as-directory (lean4-lake-find-dir-safe))))
-    (with-existing-directory
-      (compile (concat (lean4-get-executable lean4-lake-name) " build")))))
+  (let ((default-directory (file-name-as-directory (lean4-lake-find-dir-safe))))
+    (compile (concat (lean4-get-executable lean4-lake-name) " build"))))
 
 (provide 'lean4-lake)
 

--- a/lean4-mode.el
+++ b/lean4-mode.el
@@ -10,7 +10,7 @@
 ;; Maintainer: Sebastian Ullrich <sebasti@nullri.ch>
 ;; Created: Jan 09, 2014
 ;; Keywords: languages
-;; Package-Requires: ((emacs "28.1") (dash "2.18.0") (s "1.10.0") (f "0.19.0") (flycheck "30") (magit-section "2.90.1") (lsp-mode "8.0.0"))
+;; Package-Requires: ((emacs "26.3") (dash "2.18.0") (s "1.10.0") (f "0.19.0") (flycheck "30") (magit-section "2.90.1") (lsp-mode "8.0.0"))
 ;; URL: https://github.com/leanprover/lean4
 
 ;; Released under Apache 2.0 license as described in the file LICENSE.


### PR DESCRIPTION
By removing with-existing-directory which was introduced in Emacs 28.1

Note: Emacs version requirement is recently bumped to 28.1 in https://github.com/leanprover/lean4-mode/pull/27/commits/33fe005f0d1eb0b5aed8240e2963453ac4470af2. According to the commit message, this is because of the use of `with-existing-directory` which is added since Emacs 28.1.

However, `with-existing-directory` is unneeded. It's only occurence is here:

```elisp
(defun lean4-lake-find-dir-safe ()
  (or (lean4-lake-find-dir)
      (error (format "cannot find lakefile.lean for %s" (buffer-file-name)))))

(defun lean4-lake-build ()
  "Call lake build"
  (interactive)
  (let* ((default-directory (file-name-as-directory (lean4-lake-find-dir-safe))))
    (with-existing-directory
      (compile (concat (lean4-get-executable lean4-lake-name) " build")))))
```

Looking at its definition here: https://github.com/emacs-mirror/emacs/commit/6a6de68dafd27238577e92a7a79e97f3f1a6e381, the only purpose is to bind `default-directory` to some non-nil value. But we would already `error`-out when we failed to find legal `default-directory`. Besides, running `lake build` in arbitrary directory wouldn't make sense as well.