### PR TITLE
Fix setup of input method

### DIFF
--- a/lean4-input.el
+++ b/lean4-input.el
@@ -280,7 +280,7 @@ Suitable for use in the :set field of `defcustom'."
 
 ;; Set up the input method.
 
-(cl-eval-when (load)
+(cl-eval-when (load eval)
   (lean4-input-setup))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
This should fix #30. We don't want to call the function during byte-compiling (#27), but `(cl-eval-when (load) ...)` doesn't work for users of `package.el`. I have added `eval` to the triggers, like other packages do.