### PR TITLE
Add a workflow to update abbreviations.json

### DIFF
--- a/.github/workflows/update-abbr.yml
+++ b/.github/workflows/update-abbr.yml
@@ -1,0 +1,23 @@
+name: Update abbreviations.json
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - run: |
+        curl "$src" |  jq 'del(.[] | select(. | match("\\$CURSOR")))' \
+          > data/abbreviations.json
+      env:
+        src: https://raw.githubusercontent.com/leanprover/vscode-lean4/master/vscode-lean4/src/abbreviation/abbreviations.json
+
+    - uses: peter-evans/create-pull-request@v4
+      with:
+        title: 'chore: Update abbreviations.json'
+        branch: update-abbreviations
+        labels: automation,update


### PR DESCRIPTION
`abbreviations.json` of the VSCode extension is sometimes [updated](https://github.com/leanprover/vscode-lean4/commits/master/vscode-lean4/src/abbreviation/abbreviations.json), so it would be nice if it were automatically synchronized.

This PR adds a GitHub workflow that lets you updates the file in this repository manually via `workflow_dispatch` trigger. You can try it after you merge this PR.

Also, it is possible to trigger this workflow automatically from an external repository via `workflow_call` trigger (see [Reusing workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows) documentation). Once [vscode-lean4](https://github.com/leanprover/vscode-lean4) accepts a PR to add a new workflow to trigger the workflow, the file will be automatically synchronized. Note you may require some permission settings.