### PR TITLE
fix invalid escape in doc string

### DIFF
--- a/lean4-input.el
+++ b/lean4-input.el
@@ -74,11 +74,11 @@ removing all space and newline characters."
 ;; Functions used to tweak translation pairs
 
 (defun lean4-input-compose (f g)
-  "\x -> concatMap F (G x)"
+  "\\x -> concatMap F (G x)"
   (lambda (x) (lean4-input-concat-map f (funcall g x))))
 
 (defun lean4-input-or (f g)
-  "\x -> F x ++ G x"
+  "\\x -> F x ++ G x"
   (lambda (x) (append (funcall f x) (funcall g x))))
 
 (defun lean4-input-nonempty ()


### PR DESCRIPTION
According to [Elisp Manual](https://www.gnu.org/software/emacs/manual/html_node/elisp/Non_002dASCII-in-Strings.html), \x is used for hexadecimal escape sequences. The two "\x" in doc string might cause package to fail. (I cannot use this package on my emacs because of this reason).

By the way, according to this question on stack overflow: https://stackoverflow.com/questions/14701550/escaping-backslash-in-elisp, it might be impossible to see emacs prints "\x".