### PR TITLE
Don't permanently change Emacs standard-output.

### DIFF
--- a/lean4-info.el
+++ b/lean4-info.el
@@ -61,8 +61,8 @@
      (with-current-buffer buf
        (setq buffer-read-only nil)
        (erase-buffer)
-       (setq standard-output buf)
-       ,@body
+       (let ((standard-output buf))
+         ,@body)
        (setq buffer-read-only t))))
 
 (defun lean4-ensure-info-buffer (buffer)


### PR DESCRIPTION
The macro `lean4-with-info-output-to-buffer` sets the Emacs global dynamic variable `standard-output` to the specified buffer, and doesn't set it back to its original value. This can cause other Emacs programs to go wrong subsequently. For example, "package.el" assumes that `standard-output` has its default value, so after using lean4-mode, it is impossible to update Emacs packages.

This commit limits the duration of the change of `standard-output` by using `let` instead of `setq`.
