### PR TITLE
Silence byte-compiler warnings

### DIFF
--- a/lean4-fringe.el
+++ b/lean4-fringe.el
@@ -75,7 +75,7 @@
 (defvar-local lean4-fringe-data nil)
 
 (defun lean4-fringe-update-progress-overlays ()
-  "Update 'processing' bars in the current buffer."
+  "Update `processing' bars in the current buffer."
   (dolist (ov (flatten-tree (overlay-lists)))
     (when (eq (overlay-get ov 'face) 'lean4-fringe-face)
       (delete-overlay ov)))

--- a/lean4-fringe.el
+++ b/lean4-fringe.el
@@ -75,7 +75,7 @@
 (defvar-local lean4-fringe-data nil)
 
 (defun lean4-fringe-update-progress-overlays ()
-  "Update `processing' bars in the current buffer."
+  "Update processing bars in the current buffer."
   (dolist (ov (flatten-tree (overlay-lists)))
     (when (eq (overlay-get ov 'face) 'lean4-fringe-face)
       (delete-overlay ov)))

--- a/lean4-info.el
+++ b/lean4-info.el
@@ -276,7 +276,7 @@ prevent lag, because magit is quite slow at building sections."
     (lsp-request-async
      "$/lean/plainGoal"
      (lsp--text-document-position-params)
-     (-lambda ((_ &as &lean:PlainGoal? :goals))
+     (-lambda ((ignored &as &lean:PlainGoal? :goals))
        (setq lean4-goals goals)
        (lean4-info-buffer-redisplay-debounced))
      :error-handler #'ignore
@@ -285,7 +285,7 @@ prevent lag, because magit is quite slow at building sections."
     (lsp-request-async
      "$/lean/plainTermGoal"
      (lsp--text-document-position-params)
-     (-lambda ((_ &as &lean:PlainTermGoal? :goal))
+     (-lambda ((ignored &as &lean:PlainTermGoal? :goal))
        (setq lean4-term-goal goal)
        (lean4-info-buffer-redisplay-debounced))
      :error-handler #'ignore

--- a/lean4-input.el
+++ b/lean4-input.el
@@ -256,6 +256,7 @@ a list of such pairs."
 ;; Setting up the input method
 
 (defvar json-key-type)
+(declare-function json-read "json")
 
 (defun lean4-input-setup ()
   "Set up the Lean input method.

--- a/lean4-input.el
+++ b/lean4-input.el
@@ -42,7 +42,6 @@
 (require 'subr-x)
 (require 'dash)
 (require 'map)
-(require 'json)
 
 ;; Quail is quite stateful, so be careful when editing this code.  Note
 ;; that with-temp-buffer is used below whenever buffer-local state is
@@ -256,6 +255,8 @@ a list of such pairs."
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Setting up the input method
 
+(defvar json-key-type)
+
 (defun lean4-input-setup ()
   "Set up the Lean input method.
 Use customisable variables and parent input methods to setup Lean input method."
@@ -282,6 +283,7 @@ tasks as well."
         ;; Back-up is still useful in case Emacs in not compiled `--with-json`.
         (if (fboundp 'json-parse-buffer)
             (json-parse-buffer)
+          (require 'json)
           (json-read)))
       (map-filter (lambda (_ s) (not (string-match-p "\\$CURSOR" s))))
       (map-apply (lambda (k s) (cons k (vector s))))

--- a/lean4-input.el
+++ b/lean4-input.el
@@ -42,6 +42,7 @@
 (require 'subr-x)
 (require 'dash)
 (require 'map)
+(require 'json)
 
 ;; Quail is quite stateful, so be careful when editing this code.  Note
 ;; that with-temp-buffer is used below whenever buffer-local state is

--- a/lean4-lake.el
+++ b/lean4-lake.el
@@ -28,13 +28,13 @@
 (require 'lean4-settings)
 
 (defun lean4-lake-find-dir-in (dir)
-  "Find a parent directory of DIR with file `lakefile.lean'."
+  "Find a parent directory of DIR with file \"lakefile.lean\"."
   (when dir
     (or (when (f-exists? (f-join dir "lakefile.lean")) dir)
 	(lean4-lake-find-dir-in (f-parent dir)))))
 
 (defun lean4-lake-find-dir ()
-  "Find a parent directory of the current file with file `lakefile.lean'."
+  "Find a parent directory of the current file with file \"lakefile.lean\"."
   (and (buffer-file-name)
        (lean4-lake-find-dir-in (f-dirname (buffer-file-name)))))
 
@@ -44,7 +44,7 @@
       (error "Cannot find lakefile.lean for %s" (buffer-file-name))))
 
 (defun lean4-lake-build ()
-  "Call `lake build'."
+  "Call lake build."
   (interactive)
   (let ((default-directory (file-name-as-directory (lean4-lake-find-dir-safe))))
     (compile (concat (lean4-get-executable lean4-lake-name) " build"))))

--- a/lean4-lake.el
+++ b/lean4-lake.el
@@ -28,13 +28,13 @@
 (require 'lean4-settings)
 
 (defun lean4-lake-find-dir-in (dir)
-  "Find a parent directory of DIR with file 'lakefile.lean'."
+  "Find a parent directory of DIR with file `lakefile.lean'."
   (when dir
     (or (when (f-exists? (f-join dir "lakefile.lean")) dir)
 	(lean4-lake-find-dir-in (f-parent dir)))))
 
 (defun lean4-lake-find-dir ()
-  "Find a parent directory of the current file with file 'lakefile.lean'."
+  "Find a parent directory of the current file with file `lakefile.lean'."
   (and (buffer-file-name)
        (lean4-lake-find-dir-in (f-dirname (buffer-file-name)))))
 
@@ -44,7 +44,7 @@
       (error "Cannot find lakefile.lean for %s" (buffer-file-name))))
 
 (defun lean4-lake-build ()
-  "Call lake build."
+  "Call `lake build'."
   (interactive)
   (let ((default-directory (file-name-as-directory (lean4-lake-find-dir-safe))))
     (compile (concat (lean4-get-executable lean4-lake-name) " build"))))

--- a/lean4-mode.el
+++ b/lean4-mode.el
@@ -64,8 +64,8 @@
 
 (defun lean4-compile-string (lake-name exe-name args file-name)
   "Command to run EXE-NAME with extra ARGS and FILE-NAME.
-If LAKE-NAME is nonempty, then prepend `LAKE-NAME env' to the command
-`EXE-NAME ARGS FILE-NAME'."
+If LAKE-NAME is nonempty, then prepend \"LAKE-NAME env\" to the command
+\"EXE-NAME ARGS FILE-NAME\"."
   (if lake-name
       (format "%s env %s %s %s" lake-name exe-name args file-name)
       (format "%s %s %s" exe-name args file-name)))

--- a/lean4-mode.el
+++ b/lean4-mode.el
@@ -64,15 +64,15 @@
 
 (defun lean4-compile-string (lake-name exe-name args file-name)
   "Command to run EXE-NAME with extra ARGS and FILE-NAME.
-If LAKE-NAME is nonempty, then prepend 'LAKE-NAME env' to the command
-'EXE-NAME ARGS FILE-NAME'."
+If LAKE-NAME is nonempty, then prepend `LAKE-NAME env' to the command
+`EXE-NAME ARGS FILE-NAME'."
   (if lake-name
       (format "%s env %s %s %s" lake-name exe-name args file-name)
       (format "%s %s %s" exe-name args file-name)))
 
 (defun lean4-create-temp-in-system-tempdir (file-name prefix)
   "Create a temp lean file and return its name.
-The new file has prefix PREFIX (defaults to 'flymake') and the same extension as
+The new file has prefix PREFIX (defaults to `flymake') and the same extension as
 FILE-NAME."
   (make-temp-file (or prefix "flymake") nil (f-ext file-name)))
 
@@ -223,7 +223,7 @@ Invokes `lean4-mode-hook'."
   (lean4-mode-setup))
 
 (defun lean4--version ()
-  "Return Lean version as a list '(MAJOR MINOR PATCH)'."
+  "Return Lean version as a list `(MAJOR MINOR PATCH)'."
   (with-temp-buffer
     (call-process (lean4-get-executable "lean") nil (list t nil) nil "-v")
     (goto-char (point-min))

--- a/lean4-util.el
+++ b/lean4-util.el
@@ -113,14 +113,15 @@ timer and kill the execution of this function."
     ;; of this function.
     (sit-for 0.0001)
     (cond (recursive
-           (-map
-            (lambda (entry)
-              (if (f-file? entry)
-                  (setq result (cons entry result))
-                (when (f-directory? entry)
-                  (setq result (cons entry result))
-                  (setq result (append result (lean4--collect-entries entry recursive))))))
-            entries))
+           (ignore
+             (-map
+              (lambda (entry)
+                (if (f-file? entry)
+                    (setq result (cons entry result))
+                  (when (f-directory? entry)
+                    (setq result (cons entry result))
+                    (setq result (append result (lean4--collect-entries entry recursive))))))
+              entries)))
           (t (setq result entries)))
     result))
 

--- a/lean4-util.el
+++ b/lean4-util.el
@@ -113,15 +113,14 @@ timer and kill the execution of this function."
     ;; of this function.
     (sit-for 0.0001)
     (cond (recursive
-           (ignore
-             (-map
-              (lambda (entry)
-                (if (f-file? entry)
-                    (setq result (cons entry result))
-                  (when (f-directory? entry)
-                    (setq result (cons entry result))
-                    (setq result (append result (lean4--collect-entries entry recursive))))))
-              entries)))
+           (mapc
+            (lambda (entry)
+              (if (f-file? entry)
+                  (setq result (cons entry result))
+                (when (f-directory? entry)
+                  (setq result (cons entry result))
+                  (setq result (append result (lean4--collect-entries entry recursive))))))
+            entries))
           (t (setq result entries)))
     result))
 


### PR DESCRIPTION
Compiling lean4-mode files in Emacs 29 gives a few warnings. These can be annoying if they cause a warning buffer to pop up during async compilation. They're not important, but they're easily fixed.

The warnings:
```
In lean4-fringe-update-progress-overlays:
lisp/lean4-mode/lean4-fringe.el:77:2: Warning: docstring has wrong usage of unescaped single quotes (use \=' or different quoting such as `...')

In toplevel form:
lisp/lean4-mode/lean4-info.el:279:17: Warning: variable `_' not left unused
lisp/lean4-mode/lean4-info.el:288:17: Warning: variable `_' not left unused

In lean4-input-setup:
lisp/lean4-mode/lean4-input.el:279:14: Warning: Unused lexical variable `json-key-type'

In end of data:
lisp/lean4-mode/lean4-input.el:284:12: Warning: the function `json-read' is not known to be defined.

In lean4-lake-find-dir-in:
lisp/lean4-mode/lean4-lake.el:30:2: Warning: docstring has wrong usage of unescaped single quotes (use \=' or different quoting such as `...')

In lean4-lake-find-dir:
lisp/lean4-mode/lean4-lake.el:36:2: Warning: docstring has wrong usage of unescaped single quotes (use \=' or different quoting such as `...')

In lean4-compile-string:
lisp/lean4-mode/lean4-mode.el:65:2: Warning: docstring has wrong usage of unescaped single quotes (use \=' or different quoting such as `...')

In lean4-create-temp-in-system-tempdir:
lisp/lean4-mode/lean4-mode.el:73:2: Warning: docstring has wrong usage of unescaped single quotes (use \=' or different quoting such as `...')

In lean4--version:
lisp/lean4-mode/lean4-mode.el:225:2: Warning: docstring has wrong usage of unescaped single quotes (use \=' or different quoting such as `...')

In lean4--collect-entries:
lisp/lean4-mode/lean4-util.el:116:13: Warning: value from call to `-map' is unused
````