### PR TITLE
Avoid clearing echo area during info-buffer redisplay

### DIFF
--- a/lean4-info.el
+++ b/lean4-info.el
@@ -51,7 +51,6 @@
   (set (make-local-variable 'font-lock-defaults) lean4-info-font-lock-defaults)
   (set (make-local-variable 'indent-tabs-mode) nil)
   (set 'compilation-mode-font-lock-keywords '())
-  (set-input-method "Lean")
   (set (make-local-variable 'lisp-indent-function)
        'common-lisp-indent-function))
 


### PR DESCRIPTION
**Recipe:** visit a file in lean4-mode and insert the following text:
```
example (x y z : Nat) (h : x = y) (k : y = z) : x = z := by
  rw [← k, ← h]
```
Display the info buffer (`C-c TAB`). Move point over the `rw`.
**Actual behaviour:** The documentation for `rw` is briefly displayed, then the info buffer flickers and the documentation is cleared.
**Desired behaviour:** The documentation for `rw` is displayed until the next Emacs command is executed.

When lean4-info-mode is entered asynchronously (for fontification) in "lean4-info-buffer-redisplay", the major-mode function calls `set-input-method`, which has the side effect of clearing the echo area. ~~Since the info buffer is read-only, there is no need for an input method,~~ [Edit: Since the fontification is done in a temporary buffer, the input method can never be used,] so this commit simply removes the call to `set-input-method`.
