### PR TITLE
Refactor lake find dir

### DIFF
--- a/lean4-lake.el
+++ b/lean4-lake.el
@@ -24,16 +24,21 @@
 (require 'lean4-util)
 (require 'lean4-settings)
 
+(defun lean4-root-dir-p (dir)
+  (or
+   (file-exists-p (expand-file-name "lakefile.lean" dir))
+   (file-exists-p (expand-file-name "lakefile.toml" dir))))
 
 (defun lean4-lake-find-dir ()
-  "Find a parent directory of the current file with file \"lakefile.lean\"."
+  "Find a parent directory of the current file with a \"lakefile.lean\"
+  or \"lakefile.toml\" file."
   (and (buffer-file-name)
-       (locate-dominating-file (buffer-file-name) "lakefile.lean")))
+       (locate-dominating-file (buffer-file-name) #'lean4-root-dir-p)))
 
 (defun lean4-lake-find-dir-safe ()
   "Call `lean4-lake-find-dir', error on failure."
   (or (lean4-lake-find-dir)
-      (error "Cannot find lakefile.lean for %s" (buffer-file-name))))
+      (error "Cannot find lakefile in any directory above %s" (buffer-file-name))))
 
 (defun lean4-lake-build ()
   "Call lake build."

--- a/lean4-lake.el
+++ b/lean4-lake.el
@@ -25,10 +25,9 @@
 (require 'lean4-settings)
 
 (defun lean4-lake-find-dir-in (dir)
-  "Find a parent directory of DIR with file \"lakefile.lean\"."
-  (when dir
-    (or (when (file-exists-p (expand-file-name "lakefile.lean" dir)) dir)
-	(lean4-lake-find-dir-in (file-name-directory (directory-file-name dir))))))
+  "Find a parent directory of DIR with file \"lakefile.lean\" or
+  \"lakefile.toml\"."
+  (locate-dominating-file dir "lakefile.lean"))
 
 (defun lean4-lake-find-dir ()
   "Find a parent directory of the current file with file \"lakefile.lean\"."

--- a/lean4-lake.el
+++ b/lean4-lake.el
@@ -24,15 +24,11 @@
 (require 'lean4-util)
 (require 'lean4-settings)
 
-(defun lean4-lake-find-dir-in (dir)
-  "Find a parent directory of DIR with file \"lakefile.lean\" or
-  \"lakefile.toml\"."
-  (locate-dominating-file dir "lakefile.lean"))
 
 (defun lean4-lake-find-dir ()
   "Find a parent directory of the current file with file \"lakefile.lean\"."
   (and (buffer-file-name)
-       (lean4-lake-find-dir-in (directory-file-name (buffer-file-name)))))
+       (locate-dominating-file (buffer-file-name) "lakefile.lean")))
 
 (defun lean4-lake-find-dir-safe ()
   "Call `lean4-lake-find-dir', error on failure."

--- a/lean4-lake.el
+++ b/lean4-lake.el
@@ -25,6 +25,7 @@
 (require 'lean4-settings)
 
 (defun lean4-root-dir-p (dir)
+  "Check if directory DIR contains \"lakefile.lean\" or \"lakefile.toml\"."
   (or
    (file-exists-p (expand-file-name "lakefile.lean" dir))
    (file-exists-p (expand-file-name "lakefile.toml" dir))))

--- a/lean4-lake.el
+++ b/lean4-lake.el
@@ -31,8 +31,9 @@
    (file-exists-p (expand-file-name "lakefile.toml" dir))))
 
 (defun lean4-lake-find-dir ()
-  "Find a parent directory of the current file with a \"lakefile.lean\"
-  or \"lakefile.toml\" file."
+  "Find a parent directory of the current file with a Lake file.
+
+  It looks for files named \"lakefile.lean\" or \"lakefile.toml\" file."
   (and (buffer-file-name)
        (locate-dominating-file (buffer-file-name) #'lean4-root-dir-p)))
 


### PR DESCRIPTION
Fixes

```
lean4-lake-find-dir-in: Lisp nesting exceeds ‘max-lisp-eval-depth’: 1601
````

See also Issue #90