### PR TITLE
Fix typos and malformed autoload cookie

### DIFF
--- a/lean4-input.el
+++ b/lean4-input.el
@@ -195,7 +195,7 @@ All the translation strings are possible translations
 of the given key sequence; if there is more than one you can choose
 between them using the arrow keys.
 
-These translation pairs are included first, before thoseinherited
+These translation pairs are included first, before those inherited
 from other input methods."
   :group 'lean4-input
   :set 'lean4-input-incorporate-changed-setting

--- a/lean4-mode.el
+++ b/lean4-mode.el
@@ -271,7 +271,7 @@ of the parent project."
                '("lean" . lean4-select-mode)))
 
 ;; Use utf-8 encoding
-;;;### autoload
+;;;###autoload
 (modify-coding-system-alist 'file "\\.lean\\'" 'utf-8)
 
 ;; LSP init

--- a/lean4-settings.el
+++ b/lean4-settings.el
@@ -91,7 +91,7 @@ It is approximately the maximum number of memory allocations in thousands."
   :type '(list string))
 
 (defcustom lean4-delete-trailing-whitespace nil
-  "Automatically delete trailing shitespace.
+  "Automatically delete trailing whitespace.
 Set this variable to true to automatically delete trailing
 whitespace when a buffer is loaded from a file or when it is
 written."

--- a/lean4-util.el
+++ b/lean4-util.el
@@ -28,7 +28,7 @@
 (defun lean4-setup-rootdir ()
   "Search for lean executable in variable `exec-path'.
 Try to find an executable named `lean4-executable-name' in variable `exec-path'.
-On succsess, return path to the directory with this executable."
+On success, return path to the directory with this executable."
   (let ((root (executable-find lean4-executable-name)))
     (when root
       (setq lean4-rootdir (file-name-directory


### PR DESCRIPTION
- lean4-settings.el: "shitespace" -> "whitespace"
- lean4-util.el: "succsess" -> "success"
- lean4-input.el: "thoseinherited" -> "those inherited"
- lean4-mode.el: ";;;### autoload" -> ";;;###autoload"