### PR TITLE
fix(lean4-lake): quote executable path in lake build command

### DIFF
--- a/lean4-lake.el
+++ b/lean4-lake.el
@@ -46,7 +46,7 @@
   "Call lake build."
   (interactive)
   (let ((default-directory (file-name-as-directory (lean4-lake-find-dir-safe))))
-    (compile (concat (lean4-get-executable lean4-lake-name) " build"))))
+    (compile (concat (shell-quote-argument (lean4-get-executable lean4-lake-name)) " build"))))
 
 (provide 'lean4-lake)
 ;;; lean4-lake.el ends here


### PR DESCRIPTION
lean4-lake-build passed the lake executable path to compile without shell-quote-argument. Paths containing spaces or shell metacharacters would break the compile command.