### PR TITLE
fix(lean4-fringe): remove duplicate defvar-local declaration

### DIFF
--- a/lean4-fringe.el
+++ b/lean4-fringe.el
@@ -85,8 +85,6 @@
                                  `(left-fringe lean4-fringe-fringe-bitmap ,(lean4-fringe-fringe-face item))))
         (overlay-put ov 'help-echo (format "processing..."))))))
 
-(defvar-local lean4-fringe-delay-timer nil)
-
 (lsp-defun lean4-fringe-update (workspace (&lean:LeanFileProgressParams :processing :text-document (&VersionedTextDocumentIdentifier :uri)))
   (dolist (buf (lsp--workspace-buffers workspace))
     (lsp-with-current-buffer buf


### PR DESCRIPTION
lean4-fringe-delay-timer was declared twice with defvar-local at lines 34 and 88. The second declaration shadowed the first and was redundant. Remove it.